### PR TITLE
Disable chrono default features. Fix RUSTSEC-2020-0071.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures = "0.3.26"
 bytes = "1.4.0"
 http-body = "0.4.5"
 dashmap = "5.4.0"
-chrono = { version = "0.4.24", features = ["clock", "serde", "std"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde", "std"] }
 tokio = { version = "1.26.0", features = ["full"] }
 serde = "1.0.155"
 


### PR DESCRIPTION
This should remove the complaint about RUSTSEC-2020-0071 being caused by the axum_session library. It may still appear due to the usage of default features in surrealdb lib, if surrealdb feature is enabled in this lib. I've also suggested they do this.

I ran `cargo fmt` and it added a newline to this as well.